### PR TITLE
#7 extended documentation for getID() and read(); non-blocking getIDOnce() and readOnce() methods

### DIFF
--- a/MFRC522.ts
+++ b/MFRC522.ts
@@ -448,6 +448,20 @@ namespace MFRC522 {
        return id
    }
 
+   /*
+    * Function to try reading ID from card without waiting for a card to be presented
+    * If no ID is found, 0 is returned
+    */
+   //% block="Read ID once"
+   //% weight=95
+   export function getIDOnce() {
+       let id = readID()
+       if (id!=undefined){
+          return id
+       }
+       return 0
+   }
+
     /*
      * Function to read Data from card
      */
@@ -463,6 +477,20 @@ namespace MFRC522 {
            }
        }
        return text
+   }
+
+    /*
+     * Function to try reading Data from card without waiting for a card to be presented
+     * If no card is presented to the reader, null is returned
+     */
+    //% block="Read data once"
+    //% weight=90
+   export function readOnce():string {
+       let text = readFromCard()
+       if (text) {
+           return text
+       }
+       return null
    }
 
 

--- a/README.md
+++ b/README.md
@@ -26,19 +26,35 @@ MFRC522.Init()
 ```
 
 ## Read ID from card
-This function reads the cards unique ID and returns it.
+This function reads the cards unique ID and returns it. This function blocks execution until a card is presented to the reader.
 
 ```typescript
 // Read unique ID
 MFRC522.getID()
 ```
 
+## Read ID from card once
+This function attempts to read the cards unique ID. In case a card is presented to the reader when the function is called, it returns the cards unique ID, otherwise it returns 0. This function does not block execution and should be called in a loop in order to detect the case when a card is presented to the reader.
+
+```typescript
+// Read unique ID once
+MFRC522.getIDOnce()
+```
+
 ## Read data from card
-Data stored on the card can be retrieved with this function.
+Data stored on the card can be retrieved with this function. This function blocks execution until a card is presented to the reader.
 
 ```typescript
 // Read data
 MFRC522.read()
+```
+
+## Read data from card once
+This function attempts to read the data stored on the card. In case a card is presented to the reader when the function is called, it returns the data stored on the card, otherwise it returns `null`. This function does not block execution and should be called in a loop in order to detect the case when a card is presented to the reader.
+
+```typescript
+// Read data once
+MFRC522.readOnce()
 ```
 
 ## Write data to card


### PR DESCRIPTION
This PR attempts to make the documentation clearer on how `getID()` and `read()` methods work and also adds two new methods `getIDOnce()` and `readOnce()` that can be used in user's own loop on a non-blocking way.